### PR TITLE
Support importing in webpack 4, CDN scripts as modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ friends to visit your site with just a single line of code.
 [See this live on our documentation pages](https://immers-space.github.io/immers-client).
 
 ```html
-<script defer src="https://unpkg.com/immers-client/dist/destination.bundle.js">
+<script type="module" src="https://unpkg.com/immers-client/dist/destination.bundle.js"></script>
 ```
 
 This will add the `<immers-hud>` Web Component floating on the bottom left of your page,

--- a/WebComponentTest.ejs
+++ b/WebComponentTest.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
+  <body>
+    <immers-hud position="top-right" access-role="friends"
+                destination-name="My Immer" destination-url="https://myimmer.com/"
+                token-catcher="https://myimmer.com/"></immers-hud>
+  </body>
+</html>

--- a/babel.config.json
+++ b/babel.config.json
@@ -2,7 +2,7 @@
   "presets": [[
     "@babel/preset-env",
     {
-      "targets": ["defaults", "not ie 11"],
+      "targets": ["defaults", "not ie 11", "node 12"], // node 12 = support importing with webpack 4
       "exclude": ["web.url"], // saves 30Kb in minified bundle
       "bugfixes": true,
       "useBuiltIns": "usage",

--- a/jsdoc.layout.tmpl
+++ b/jsdoc.layout.tmpl
@@ -10,7 +10,7 @@
     <![endif]-->
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
-    <script defer src="https://unpkg.com/immers-client/dist/destination.bundle.js?position=top-right&title=immers-client%20Documentation"></script>
+    <script type="module" src="https://unpkg.com/immers-client/dist/destination.bundle.js?position=top-right&title=immers-client%20Documentation"></script>
 </head>
 
 <body>

--- a/oneLiner.js
+++ b/oneLiner.js
@@ -3,7 +3,7 @@ import { ImmersHUD } from './source/ImmersHUD/ImmersHUD.js'
 ImmersHUD.Register()
 let scriptArgs
 try {
-  scriptArgs = Object.fromEntries(new URL(document.currentScript.src).searchParams)
+  scriptArgs = Object.fromEntries(new URL(import.meta.url).searchParams)
 } catch (err) {
   scriptArgs = {}
   console.warn(`Unable to process query arguments to script, ${err.message}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2926,9 +2926,9 @@
       }
     },
     "@types/html-minifier-terser": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
-      "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.0.0.tgz",
+      "integrity": "sha512-NZwaaynfs1oIoLAV1vg18e7QMVDvw+6SQrdJc8w3BwUaoroVSf6EBj/Sk4PBWGxsq0dzhA2drbsuMC1/6C6KgQ==",
       "dev": true
     },
     "@types/http-proxy": {
@@ -3863,9 +3863,9 @@
       "dev": true
     },
     "clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz",
+      "integrity": "sha512-/eR8ru5zyxKzpBLv9YZvMXgTSSQn7AdkMItMYynsFgGwTveCRVam9IUPFloE85B4vAIj05IuKmmEoV7/AQjT0w==",
       "dev": true,
       "requires": {
         "source-map": "~0.6.0"
@@ -4207,9 +4207,9 @@
       }
     },
     "css-what": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
       "dev": true
     },
     "cssesc": {
@@ -5694,57 +5694,38 @@
       "dev": true
     },
     "html-minifier-terser": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-      "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.0.2.tgz",
+      "integrity": "sha512-AgYO3UGhMYQx2S/FBJT3EM0ZYcKmH6m9XL9c1v77BeK/tYJxGPxT1/AtsdUi4FcP8kZGmqqnItCcjFPcX9hk6A==",
       "dev": true,
       "requires": {
-        "camel-case": "^4.1.1",
-        "clean-css": "^4.2.3",
-        "commander": "^4.1.1",
+        "camel-case": "^4.1.2",
+        "clean-css": "^5.1.5",
+        "commander": "^8.1.0",
         "he": "^1.2.0",
-        "param-case": "^3.0.3",
+        "param-case": "^3.0.4",
         "relateurl": "^0.2.7",
-        "terser": "^4.6.3"
+        "terser": "^5.7.2"
       },
       "dependencies": {
         "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
           "dev": true
-        },
-        "terser": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
-          "dev": true,
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.20.3",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-              "dev": true
-            }
-          }
         }
       }
     },
     "html-webpack-plugin": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.3.2.tgz",
-      "integrity": "sha512-HvB33boVNCz2lTyBsSiMffsJ+m0YLIQ+pskblXgN9fnjS1BgEcuAfdInfXfGrkdXV406k9FiDi86eVCDBgJOyQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
+      "integrity": "sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==",
       "dev": true,
       "requires": {
-        "@types/html-minifier-terser": "^5.0.0",
-        "html-minifier-terser": "^5.0.1",
+        "@types/html-minifier-terser": "^6.0.0",
+        "html-minifier-terser": "^6.0.2",
         "lodash": "^4.17.21",
-        "pretty-error": "^3.0.4",
+        "pretty-error": "^4.0.0",
         "tapable": "^2.0.0"
       }
     },
@@ -7354,9 +7335,9 @@
       }
     },
     "nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
@@ -7906,13 +7887,13 @@
       "dev": true
     },
     "pretty-error": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-3.0.4.tgz",
-      "integrity": "sha512-ytLFLfv1So4AO1UkoBF6GXQgJRaKbiSiGFICaOPNwQ3CMvBvXpLRubeQWyPGnsbV/t9ml9qto6IeCsho0aEvwQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+      "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.20",
-        "renderkid": "^2.0.6"
+        "renderkid": "^3.0.0"
       }
     },
     "pretty-format": {
@@ -8254,31 +8235,31 @@
       "dev": true
     },
     "renderkid": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
-      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
+      "integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
       "dev": true,
       "requires": {
         "css-select": "^4.1.3",
         "dom-converter": "^0.2.0",
         "htmlparser2": "^6.1.0",
         "lodash": "^4.17.21",
-        "strip-ansi": "^3.0.1"
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@babel/preset-env": "^7.15.4",
     "babel-loader": "^8.2.2",
     "css-loader": "^6.2.0",
-    "html-webpack-plugin": "^5.3.2",
+    "html-webpack-plugin": "^5.5.0",
     "jest": "^27.0.6",
     "jsdoc": "^3.6.7",
     "standard": "^16.0.3",

--- a/source/ImmersHUD/ImmersHUD.js
+++ b/source/ImmersHUD/ImmersHUD.js
@@ -24,8 +24,10 @@ import { ImmersClient } from '../client'
  * @prop {string} [local-immer] Origin of your local Immers Server, if you have one
  * @prop {'true'|'false'} open - Toggles between icon and full HUD view
  *
- * @example <caption>Load & register the custom element so it can be used in HTML</caption>
+ * @example <caption>Load & register the custom element via import (option 1)</caption>
  * import 'immers-client/dist/ImmersHUD.bundle'
+ * @example <caption>Load & register the custom element via CDN (option 2)</caption>
+ * <script type="module" src="https://unpkg.com/immers-client/dist/ImmersHUD.bundle.js"></script>
  * @example <caption>Using the custom element in HTML</caption>
  * <immers-hud position="bottom-left" access-role="friends"
  *             destination-name="My Immer" destination-url="https://myimmer.com/"

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -12,7 +12,16 @@ module.exports = merge(common, {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      title: 'Test page'
+      title: 'One-liner test page',
+      chunks: ['destination'],
+      scriptLoading: 'module'
+    }),
+    new HtmlWebpackPlugin({
+      title: 'Webcomponent test page',
+      chunks: ['ImmersHUD'],
+      scriptLoading: 'module',
+      template: 'WebComponentTest.ejs',
+      filename: 'webcomponent.html'
     })
   ]
 })


### PR DESCRIPTION
* Add Node 12 to babel targets so optional chains and nullish coalescing operators will be transformed, preventing parsing errors in order Webpack versions
* Turns out webpack made all the outputs into modules when adding the module library output, update docs and scripts to work as modules