### PR TITLE
allow deep link to tab

### DIFF
--- a/source/authUtils.js
+++ b/source/authUtils.js
@@ -56,7 +56,6 @@ export function catchToken () {
  * @property {string} token OAuth access token
  * @property {string} homeImmer User's home Immers Server origin
  * @property {Array<string>} authorizedScopes Scopes granted by user (may differ from requested scopes)
- * @property {string} deepLink Setting active tab ['Login', 'Register', 'Reset password']
  */
 /**
  * Internal oauth popup handler
@@ -154,6 +153,7 @@ export async function DestinationOAuthPopup (handle, preferredScope, tokenCatche
  * @param  {string} preferredScope Level of access to request (remember the user can alter this before approving)
  * @param  {string} tokenCatcherURL Redirect URI for OAuth, a page on your origin that runs catchToken on load
  * @param  {string} [handle] If known, you can provide the user's handle (username[home.immer]) to pre-fill login forms
+ * @param {'Login'|'Register'|'Reset password'} [deepLink] Set the default tab to be shown on the login page
  * @returns {Promise<AuthResult>}
  */
 export function ImmerOAuthPopup (localImmer, localImmerId, preferredScope, tokenCatcherURL, handle, deepLink) {

--- a/source/authUtils.js
+++ b/source/authUtils.js
@@ -56,12 +56,13 @@ export function catchToken () {
  * @property {string} token OAuth access token
  * @property {string} homeImmer User's home Immers Server origin
  * @property {Array<string>} authorizedScopes Scopes granted by user (may differ from requested scopes)
+ * @property {string} deepLink Setting active tab ['Login', 'Register', 'Reset password']
  */
 /**
  * Internal oauth popup handler
  * @returns {Promise<AuthResult>}
  */
-function oauthPopup (oauthPath, { clientId, redirectURI, preferredScope, handle }) {
+function oauthPopup (oauthPath, { clientId, redirectURI, preferredScope, handle, deepLink }) {
   // center the popup
   const width = 785
   const height = 785
@@ -74,7 +75,8 @@ function oauthPopup (oauthPath, { clientId, redirectURI, preferredScope, handle 
     redirect_uri: redirectURI,
     response_type: 'token',
     scope: preferredScope,
-    me: handle
+    me: handle, 
+    tab: deepLink
   })
   authURL.search = authURLParams.toString()
   const popup = window.open(authURL, 'immersLoginPopup', features)
@@ -154,12 +156,13 @@ export async function DestinationOAuthPopup (handle, preferredScope, tokenCatche
  * @param  {string} [handle] If known, you can provide the user's handle (username[home.immer]) to pre-fill login forms
  * @returns {Promise<AuthResult>}
  */
-export function ImmerOAuthPopup (localImmer, localImmerId, preferredScope, tokenCatcherURL, handle) {
+export function ImmerOAuthPopup (localImmer, localImmerId, preferredScope, tokenCatcherURL, handle, deepLink) {
   return oauthPopup(`https://${localImmer}/auth/authorize`, {
     clientId: localImmerId,
     redirectURI: tokenCatcherURL,
     preferredScope,
-    handle
+    handle,
+    deepLink
   })
 }
 


### PR DESCRIPTION
Is this how you would handle the ability to send along a deep link to a specific tab? In the immers code I have ```let activeTabString = qParams.has('tab') ? qParams.get('tab') : 'Login';

    this.state = {
      data,
      currentState: undefined,
      tabs: ['Login', 'Register', 'Reset password'],
      tab: activeTabString,
      username: data.username || '',
      immer: data.immer || '',
      passwordError: qParams.has('passwordfail'),
      ...this.initialState
    }
    if (this.state.tabs.includes(data.loginTab)) {
      this.state.tab = data.loginTab || activeTabString
    }```