### PR TITLE
High-level API messaging & presence updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4488,6 +4488,11 @@
         "domelementtype": "^2.2.0"
       }
     },
+    "dompurify": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.6.tgz",
+      "integrity": "sha512-OFP2u/3T1R5CEgWCEONuJ1a5+MFKnOYpkywpUSxv/dj1LeBT1erK+JwM7zK0ROy2BRhqVCf0LRw/kHqKuMkVGg=="
+    },
     "domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "core-js": "^3.17.2",
+    "dompurify": "^2.3.6",
     "socket.io-client": "^4.0.0"
   }
 }

--- a/source/activities.js
+++ b/source/activities.js
@@ -152,7 +152,8 @@ export class Activities {
       type: 'Accept',
       actor: this.actor.id,
       object: follow.id,
-      to: follow.actor
+      to: follow.actor,
+      summary: '<span>Accepted your a friend request</span>'
     })
   }
 
@@ -170,13 +171,23 @@ export class Activities {
     })
   }
 
-  arrive () {
+  arrive (place = this.place) {
     return this.postActivity({
       type: 'Arrive',
       actor: this.actor.id,
-      target: this.place,
+      target: place,
       to: this.actor.followers,
-      summary: `${this.actor.name} arrived at ${this.place.name}.`
+      summary: `<span>Arrived at <a href="${place.url}">${place.name}</a></span>`
+    })
+  }
+
+  leave (place = this.place) {
+    return this.postActivity({
+      type: 'Leave',
+      actor: this.actor.id,
+      target: place,
+      to: this.actor.followers,
+      summary: `<span>Left <a href="${place.url}">${place.name}</a></span>`
     })
   }
 
@@ -211,7 +222,8 @@ export class Activities {
       type: 'Follow',
       actor: this.actor.id,
       object: targetId,
-      to: targetId
+      to: targetId,
+      summary: '<span>Sent you a friend request</span>'
     })
   }
 

--- a/source/activities.js
+++ b/source/activities.js
@@ -75,11 +75,11 @@ export class Activities {
     }
   }
 
-  postActivity (activity) {
+  async postActivity (activity) {
     if (!this.trustedIRI(this.actor.outbox)) {
       throw new Error('Invalid outbox address')
     }
-    return window.fetch(this.actor.outbox, {
+    const result = await window.fetch(this.actor.outbox, {
       method: 'POST',
       headers: {
         'Content-Type': Activities.JSONLDMime,
@@ -87,6 +87,10 @@ export class Activities {
       },
       body: JSON.stringify(activity)
     })
+    if (!result.ok) {
+      throw new Error(`Error creating avatar: ${result.status} ${result.body}`)
+    }
+    return result.headers.get('Location')
   }
 
   // collection fetchers

--- a/source/client.js
+++ b/source/client.js
@@ -288,6 +288,21 @@ export class ImmersClient extends window.EventTarget {
       .sort(desc('timestamp'))
   }
 
+  /**
+   * Send a message with text content.
+   * Privacy level determines who receives and can acccess the message.
+   * Direct: Only those named in `to` receive the message.
+   * Friends: Direct plus friends list.
+   * Public: Direct plus Friends plus accessible via URL for sharing.
+   * @param {string} content - The text/HTML content. Will be sanitized before sending
+   * @param {string} privacy - 'direct', 'friends', or 'public'
+   * @param {string[]} [to] - Addressees. Accepts Immers handles (username[domain.name]) and ActivityPub IRIs
+   * @returns {Promise<string>} Url of newly posted message
+   */
+  async sendChatMessage (content, privacy, to = []) {
+    return this.activities.note(DOMPurify.sanitize(content), to, privacy)
+  }
+
   async #publishFriendsUpdate () {
     /**
      * Friends status/location has changed

--- a/source/streaming.js
+++ b/source/streaming.js
@@ -3,6 +3,12 @@ import io from 'socket.io-client'
 export class ImmersSocket extends window.EventTarget {
   #token
   /**
+   * Is the socket connection active
+   * @type {boolean}
+   * @public
+   */
+  connected = false
+  /**
    * @param  {string} homeImmer
    * @param  {string} token
    */
@@ -19,6 +25,7 @@ export class ImmersSocket extends window.EventTarget {
       }
     })
     this.socket.on('connect', () => {
+      this.connected = true
       this.dispatchEvent(new window.CustomEvent('immers-socket-connect'))
     })
     this.socket.on('friends-update', () => {
@@ -54,5 +61,6 @@ export class ImmersSocket extends window.EventTarget {
    */
   disconnect () {
     this.socket?.disconnect()
+    this.connected = false
   }
 }

--- a/source/utils.js
+++ b/source/utils.js
@@ -19,3 +19,15 @@ export function parseHandle (handle) {
   }
   return {}
 }
+
+export function desc (prop) {
+  return (a, b) => {
+    if (a[prop] < b[prop]) {
+      return 1
+    }
+    if (b[prop] < a[prop]) {
+      return -1
+    }
+    return 0
+  }
+}


### PR DESCRIPTION
Presence:

* Deprecated `connect` & `reconnect` methods that combined login and presence
* New `login`/`restoreSession` methods to connect to immers account
* New `enter`/`exit` methods to update status to online at your immer or offline
* New `move` method to change the current online location (e.g. when your app can navigating to a different room without reloading the page)

Messaging:

* New type: `Message`
* New `ImmersClient` event: `immers-client-new-message` when a message is received in inbox while connected
* New method `feed` to fetch past inbox & outbox activity
* All message content is now purified with DOMPurify
* New method `sendChatMessage` to publish a text/HTML content post