### PR TITLE
Improved usability with local immers, loginWithToken feature

### DIFF
--- a/source/activities.js
+++ b/source/activities.js
@@ -28,6 +28,8 @@
  * @property {String} audience who can view this object (generally Activities.PublicAddress)
  */
 
+import { getURLPart } from './utils'
+
 /** Low-level API client-to-server ActivityPub methods */
 export class Activities {
   static JSONLDMime = 'application/activity+json'
@@ -41,14 +43,14 @@ export class Activities {
    * @param  {string} homeImmer Protocol and domain of user's home Immers server
    * @param  {APObject} place Place-type object representing this Immersive Web experience
    * @param  {string} [token] OAuth2 token for user's home Immers server
-   * @param  {string} [localImmer] Protocol and domain of local Immers server, e.g. https://immers.space
+   * @param  {string} [localImmer] Origin of local Immers server, e.g. https://immers.space
    */
   constructor (actor, homeImmer, place, token, localImmer) {
     this.actor = actor
     this.homeImmer = homeImmer
     this.place = place
     this.#token = token
-    this.localImmer = localImmer
+    this.localImmer = localImmer ? getURLPart(localImmer, 'origin') : undefined
     // this.authorizedScopes = null
     this.nextInboxPage = null
     this.nextOutboxPage = null

--- a/source/authUtils.js
+++ b/source/authUtils.js
@@ -119,7 +119,7 @@ function oauthPopup (oauthPath, { clientId, redirectURI, preferredScope, handle,
         return reject(new Error('Not authorized'))
       }
       const { token, homeImmer } = data
-      const authorizedScopes = data.authorizedScopes[0] === '*' ? allScopes : data.authorizedScopes
+      const authorizedScopes = preprocessScopes(data.authorizedScopes)
       window.removeEventListener('message', handler)
       // have to close the popup in this thread because, in chrome, having the popup close itself crashes the browser
       popup?.close()
@@ -203,4 +203,11 @@ export async function tokenToActor (token, homeImmer) {
     throw new Error(`Error fetching actor ${response.status} ${response.statusText}`)
   }
   return response.json()
+}
+
+export function preprocessScopes (authorizedScopes) {
+  if (typeof authorizedScopes === 'string') {
+    authorizedScopes = authorizedScopes.split(' ')
+  }
+  return authorizedScopes[0] === '*' ? allScopes : authorizedScopes
 }

--- a/source/client.js
+++ b/source/client.js
@@ -1,6 +1,6 @@
 import DOMPurify from 'dompurify'
 import { Activities } from './activities.js'
-import { ImmerOAuthPopup, DestinationOAuthPopup, tokenToActor, SCOPES } from './authUtils.js'
+import { ImmerOAuthPopup, DestinationOAuthPopup, tokenToActor, SCOPES, preprocessScopes } from './authUtils.js'
 import { desc, getURLPart, parseHandle } from './utils.js'
 import { ImmersSocket } from './streaming.js'
 import { clearStore, createStore } from './store.js'
@@ -148,11 +148,12 @@ export class ImmersClient extends window.EventTarget {
    * e.g. one obtained through a service account
    * @param  {string} token - OAuth2 Access Token
    * @param  {string} homeImmer - Domain (host) for user's home immer
-   * @param  {string[]} authorizedScopes - Scopes authorized for the token
+   * @param  {(string|string[])} authorizedScopes - Scopes authorized for the token
    * @returns {Promise<boolean>} true if the login was successful
    */
   loginWithToken (token, homeImmer, authorizedScopes) {
     homeImmer = getURLPart(homeImmer, 'origin')
+    authorizedScopes = preprocessScopes(authorizedScopes)
     this.#store.credential = { token, homeImmer, authorizedScopes }
     return this.restoreSession()
   }

--- a/source/utils.js
+++ b/source/utils.js
@@ -31,3 +31,23 @@ export function desc (prop) {
     return 0
   }
 }
+/**
+ * Process a url-like input into a fully formed URL in order to fetch
+ * a specific portion via the URL API
+ * @param  {string} input - potentially incomplete origin, e.g. domain/hostname, host, or origin
+ * @param  {string} part - property name from the URL API to return, e.g. 'origin' or 'host'
+ */
+export function getURLPart (input, part) {
+  let url
+  let location = input.toString()
+  if (!/^https?:\/\//.test(location)) {
+    location = `https://${location}`
+  }
+  try {
+    url = new URL(location)
+  } catch (err) {
+    console.debug(err.message)
+    throw new Error(`Invalid URL: ${input}`)
+  }
+  return url[part]
+}


### PR DESCRIPTION
* Fix differing requirements for immer url specifications (domain, origin, et c) by accepting all forms and extracting the necessary url part
* Fix bug with not waiting for updated destination data to resolve before using
* New feature `loginWithToken`, allowing direct login (no user intervention required) when you've obtained credentials through another path (keep your eyes on immers-space/immers for a powerful new feature coming soon that will utilize this)
* When using a local immer, initialize a `client.activities` even before login to be able to take advantage of some logged-out functionality provided by the local immer, e.g. getObject for fetching AP objects on local immer