### PR TITLE
OAuth ClientID and FriendStatus.isOnline bugfixes, changing location when going online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 * `ImmersClient.friendsList` sort updated to list online friends first
+* `ImmersClient.enter` now takes an optional destination argument that will update the current location before going online
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 * `ImmersClient.friendsList` sort updated to list online friends first
 
-## Fixed
+### Fixed
 
 * Fix memory leak in oauth popup that could cause page to crash if left open
+* OAuth client ID incorrect when using with local immer
 
 ## v2.4.0 (2022-04-23)
 ### Friend management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Fixed
 
 * Fix memory leak in oauth popup that could cause page to crash if left open
-* OAuth client ID incorrect when using with local immer
+* OAuth client ID was incorrect when using with local immer
+* FriendStatus.isOnline is now `true` when friend is online
 
 ## v2.4.0 (2022-04-23)
 ### Friend management

--- a/source/client.js
+++ b/source/client.js
@@ -97,19 +97,9 @@ export class ImmersClient extends window.EventTarget {
    */
   constructor (destinationDescription, options) {
     super()
-    this.enterBound = this.enter.bind(this)
-    this.#setPlaceFromDestination(destinationDescription).then(() => {
-      if (!this.place.id) {
-        // fake AP IRI for destinations without their own immer
-        this.place.id = this.place.url
-      }
-    })
     this.localImmer = options?.localImmer ? getURLPart(options.localImmer, 'host') : undefined
-    if (this.localImmer) {
-      // some functionality enabled prior to login when local immer present
-      this.activities = new Activities({}, this.localImmer, this.place, null, this.localImmer)
-    }
     this.allowStorage = options?.allowStorage
+    this.enterBound = this.enter.bind(this)
     this.#store = createStore(this.allowStorage)
     try {
       const hashParams = new URLSearchParams(window.location.hash.substring(1))
@@ -122,6 +112,16 @@ export class ImmersClient extends window.EventTarget {
     } catch (err) {
       console.warn(`Unable to parse handle from URL hash: ${err.message}`)
     }
+    if (this.localImmer) {
+      // some functionality enabled prior to login when local immer present
+      this.activities = new Activities({}, this.localImmer, this.place, null, this.localImmer)
+    }
+    this.#setPlaceFromDestination(destinationDescription).then(() => {
+      if (!this.place.id) {
+        // fake AP IRI for destinations without their own immer
+        this.place.id = this.place.url
+      }
+    })
   }
 
   /**

--- a/source/client.js
+++ b/source/client.js
@@ -99,7 +99,7 @@ export class ImmersClient extends window.EventTarget {
     super()
     this.localImmer = options?.localImmer ? getURLPart(options.localImmer, 'host') : undefined
     this.allowStorage = options?.allowStorage
-    this.enterBound = this.enter.bind(this)
+    this.enterBound = () => this.enter()
     this.#store = createStore(this.allowStorage)
     try {
       const hashParams = new URLSearchParams(window.location.hash.substring(1))
@@ -179,8 +179,13 @@ export class ImmersClient extends window.EventTarget {
   /**
    * Mark user as "online" at this immer and share the location with their friends.
    * Must be called after successful {@link login} or {@link restoreSession}
+   *  @param  {(Destination|APPlace|string)} [destinationDescription]
    */
-  async enter () {
+  async enter (destinationDescription) {
+    // optionally update the place before going online
+    if (destinationDescription) {
+      await this.#setPlaceFromDestination(destinationDescription)
+    }
     if (!this.connected) {
       throw new Error('Immers login required to udpate location')
     }
@@ -210,8 +215,7 @@ export class ImmersClient extends window.EventTarget {
       return
     }
     await this.exit()
-    await this.#setPlaceFromDestination(destinationDescription)
-    return this.enter()
+    return this.enter(destinationDescription)
   }
 
   /**

--- a/source/client.js
+++ b/source/client.js
@@ -670,7 +670,7 @@ export class ImmersClient extends window.EventTarget {
         }
         break
     }
-    const isOnline = status === 'online'
+    const isOnline = status === 'friend-online'
     const friendStatus = {
       profile: ImmersClient.ProfileFromActor(actor),
       isOnline,


### PR DESCRIPTION
- Reordered ImmersClient constructor tasks so that settings will be stored before they are accessed
- Wrong string was used in isOnline logic
- Allow optionally changing location in an `enter` call, useful if the user's location changed while they were offline and now they need to go online at the new location