### PR TITLE
Add GetConnected util static method

### DIFF
--- a/source/client.js
+++ b/source/client.js
@@ -134,7 +134,7 @@ export class ImmersClient extends window.EventTarget {
       return client;
     }
 
-    return new Promise(res => client.addEventListener("immers-client-connected", () => res(client)));
+    return new Promise(res => client.addEventListener("immers-client-connected", () => res(client), { once: true }));
   };
 
   /**

--- a/source/client.js
+++ b/source/client.js
@@ -125,6 +125,19 @@ export class ImmersClient extends window.EventTarget {
   }
 
   /**
+   * Utility method to hide details for waiting on a client connection
+   * @param {ImmersClient} client
+   * @returns {ImmersClient}
+   */
+  static async GetConnected (client) {
+    if (client.connected) {
+      return client;
+    }
+
+    return new Promise(res => client.addEventListener("immers-client-connected", () => res(client)));
+  };
+
+  /**
    * Connect to user's Immers Space profile, using pop-up window for OAuth
    * @param  {string} tokenCatcherURL Page on your domain that runs {@link catchToken} on load to retrieve the granted access token.
    * Can be the same page as long as loading it again in a pop-up won't cause a the main session to disconnect.


### PR DESCRIPTION
### Changes
- Add a `GetConnected` static method to `client.js` to hide the details for waiting for a connection to be made

### TODO
- Looking for feedback in general. Should this be a static or instance method? I think it could be either or both, but static felt right.
- Contribute to the docs?
- This code is untested loL