### PR TITLE
Profile sync events, improved profile and friend status data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Added
+
+* New event `immers-client-profile-update` fires whenever logged-in user's profile
+has changed
+* Added `avatarId` prop to `Profile`
+
 ### Fixed
 
 * Restore summary messages in arrive/leave activities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * New event `immers-client-profile-update` fires whenever logged-in user's profile
 has changed
+* New method `immersClient.waitUntilConnected`, utility to simplify timing checks when a logged-in user is required (contributed by @wswoodruff)
 * Added `avatarId` prop to `Profile`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 * New event `immers-client-profile-update` fires whenever logged-in user's profile
 has changed
 * New method `immersClient.waitUntilConnected`, utility to simplify timing checks when a logged-in user is required (contributed by @wswoodruff)
-* Added `bio` and `avatarObject` to `Profile`
-* Added `inbox` and `outbox` to `Profile.collections`
-* `ImmersClient.DestinationFromPlace` static method to transform ActivityPub Place to Destination type
+* New static methid `ImmersClient.DestinationFromPlace` to transform ActivityPub Place to Destination type
 
 ### Changed
 
+* Added `bio` and `avatarObject` to `Profile`
+* Added `inbox` and `outbox` to `Profile.collections`
+* Added `destination` to `FriendStatus`
 * `URLFromProperty` can also find `href` prop if given a `Link` object
 * `Activities.getObject` can accept URL object in addition to string
 * Destination urls ending with an empty fragment will have the trailing `#` dropped to more accutately aggregate Destinations history
@@ -19,7 +20,7 @@ has changed
 
 * Restore summary messages in arrive/leave activities
 * Fix local immer place object not updating
-* Fix Profile type, url for avatar 3d Model is in prop `avatarModel` not `avatarGltf`
+* Fix error in Profile type, url for avatar 3d Model is in prop `avatarModel` not `avatarGltf`
 
 ## v2.7.1 (2022-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * New event `immers-client-profile-update` fires whenever logged-in user's profile
 has changed
 * New method `immersClient.waitUntilConnected`, utility to simplify timing checks when a logged-in user is required (contributed by @wswoodruff)
-* New static methid `ImmersClient.DestinationFromPlace` to transform ActivityPub Place to Destination type
+* New static method `ImmersClient.DestinationFromPlace` to transform ActivityPub Place to Destination type
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 has changed
 * Added `avatarId` prop to `Profile`
 
+### Changed
+
+* `URLFromProperty` can also find `href` prop if given a `Link` object
+
 ### Fixed
 
 * Restore summary messages in arrive/leave activities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,21 @@
 * New event `immers-client-profile-update` fires whenever logged-in user's profile
 has changed
 * New method `immersClient.waitUntilConnected`, utility to simplify timing checks when a logged-in user is required (contributed by @wswoodruff)
-* Added `avatarId` prop to `Profile`
+* Added `bio` and `avatarObject` to `Profile`
+* Added `inbox` and `outbox` to `Profile.collections`
+* `ImmersClient.DestinationFromPlace` static method to transform ActivityPub Place to Destination type
 
 ### Changed
 
 * `URLFromProperty` can also find `href` prop if given a `Link` object
+* `Activities.getObject` can accept URL object in addition to string
+* Destination urls ending with an empty fragment will have the trailing `#` dropped to more accutately aggregate Destinations history
 
 ### Fixed
 
 * Restore summary messages in arrive/leave activities
 * Fix local immer place object not updating
+* Fix Profile type, url for avatar 3d Model is in prop `avatarModel` not `avatarGltf`
 
 ## v2.7.1 (2022-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## Unreleased
+
+### Fixed
+
+* Restore summary messages in arrive/leave activities
+
 ## v2.7.1 (2022-08-04)
 
-## Fixed
+### Fixed
 
 * Type Error when loading client on destination-only sites
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 * Restore summary messages in arrive/leave activities
+* Fix local immer place object not updating
 
 ## v2.7.1 (2022-08-04)
 

--- a/source/activities.js
+++ b/source/activities.js
@@ -36,6 +36,15 @@
  * @property {(string|Activities.APObject|Activities.APLink)} [icon] preview image
  * @property {Activities.APPlace} [context] Main Place object representing the immer this place exists in
  */
+/**
+ * @typedef {Object} Activities.APModel
+ * @property {Activities.IRI} id
+ * @property {'Model'} type
+ * @property {string} name Model name
+ * @property {(string|Activities.APObject|Activities.APLink)} url link to 3D model file
+ * @property {(string|Activities.APObject|Activities.APLink)} [icon] preview image
+ * @property {string} audience who can view this object (generally Activities.PublicAddress)
+ */
 
 import { getURLPart, htmlAnchorForPlace } from './utils'
 
@@ -79,7 +88,7 @@ export class Activities {
     if (this.#token) {
       headers.Authorization = `Bearer ${this.#token}`
     }
-    if (this.trustedIRI(IRI)) {
+    if (this.trustedIRI(IRI.toString())) {
       result = await window.fetch(IRI, { headers })
     } else if (this.actor.endpoints?.proxyUrl) {
       result = await window.fetch(this.actor.endpoints.proxyUrl, {

--- a/source/activities.js
+++ b/source/activities.js
@@ -236,7 +236,7 @@ export class Activities {
       actor: this.actor.id,
       target: place,
       to: this.actor.followers,
-      summary: htmlAnchorForPlace(place)
+      summary: `<span>Arrived at ${htmlAnchorForPlace(place)}</span>`
     })
   }
 
@@ -246,7 +246,7 @@ export class Activities {
       actor: this.actor.id,
       target: place,
       to: this.actor.followers,
-      summary: htmlAnchorForPlace(place)
+      summary: `<span>Left ${htmlAnchorForPlace(place)}</span>`
     })
   }
 

--- a/source/client.js
+++ b/source/client.js
@@ -673,17 +673,21 @@ export class ImmersClient extends window.EventTarget {
     this.dispatchEvent(evt)
   }
 
-  /** fetch & cache the /o/immer object */
-  #getLocalImmerPlaceObject () {
-    if (this.#store.localImmerPlaceObject) {
-      return Promise.resolve(this.#store.localImmerPlaceObject)
+  #localImmerPlaceObject
+  /**
+   * fetch the /o/immer object for the current immer from memory cache or network
+   * @type {Promise<Activities.APPlace>}
+   */
+  get localImmerPlaceObject () {
+    if (this.#localImmerPlaceObject) {
+      return Promise.resolve(this.#localImmerPlaceObject)
     }
     return window.fetch(`${getURLPart(this.localImmer, 'origin')}/o/immer`, {
       headers: { Accept: Activities.JSONLDMime }
     })
       .then(res => res.json())
       .then(place => {
-        this.#store.localImmerPlaceObject = place
+        this.#localImmerPlaceObject = place
         return place
       })
       .catch(() => undefined)
@@ -889,7 +893,7 @@ export class ImmersClient extends window.EventTarget {
       if (immer) {
         place.context = immer
       } else if (this.localImmer) {
-        place.context = await this.#getLocalImmerPlaceObject()
+        place.context = await this.localImmerPlaceObject
       }
       this.place = place
     }

--- a/source/client.js
+++ b/source/client.js
@@ -26,7 +26,14 @@ import { clearStore, createStore } from './store.js'
  * @property {string} avatarModel - Profile avatar 3d model url
  * @property {Activities.APModel} avatarObject - Profile avatar full Model object
  * @property {string} url - Webpage to view full profile
- * @property {object} collections - Map of user collections retrievable with getCollection. Always includes 'inbox;', 'outbox', 'blocked' (user blocklist) and 'avatars'
+ * @property {object} collections - Map of user collections - urls to fetch lists of related activities. May include user-generated collections in addition to those listed
+ * @property {string} collections.avatars - Activities with model objects representing user's collection of avatars
+ * @property {string} collections.blocked - User blocks
+ * @property {string} collections.destinations - Unique immers visited by user, most recent first
+ * @property {string} collections.friends - Most recent activity for each friend (see {@link friendsList})
+ * @property {string} collections.friendsDestinations - Unique immers visited by user's friends, most recent first
+ * @property {string} collections.inbox - All incoming activities
+ * @property {string} collections.outbox - All outgoing activities
  */
 /**
  * @typedef {object} FriendStatus

--- a/source/client.js
+++ b/source/client.js
@@ -34,6 +34,7 @@ import { clearStore, createStore } from './store.js'
  * @property {boolean} isOnline - Currently online anywhere in Immers Space
  * @property {string} [locationName] - Name of current or last immer visited
  * @property {string} [locationURL] - URL of current or last immer visited
+ * @property {Destination} [destination] - Destination object for current or last immer visited
  * @property {('friend-online'|'friend-offline'|'request-receved'|'request-sent'|'none')} status - descriptor of the current relationship to this user
  * @property {string} statusString - Text description of current status, "Offline" / "Online at..."
  * @property {string} __unsafeStatusHTML - Unsanitized HTML description of current status with link.
@@ -827,6 +828,7 @@ export class ImmersClient extends window.EventTarget {
     const isOnline = status === 'friend-online'
     const friendStatus = {
       profile: ImmersClient.ProfileFromActor(actor),
+      destination: activity.target && ImmersClient.DestinationFromPlace(activity.target),
       isOnline,
       locationName,
       locationURL,

--- a/source/client.js
+++ b/source/client.js
@@ -126,16 +126,22 @@ export class ImmersClient extends window.EventTarget {
   }
 
   /**
-   * Utility method to hide details for waiting on a client connection
-   * @param {ImmersClient} client
-   * @returns {ImmersClient}
+   * Utility method to hide details for checking if user is logged in
+   * or waiting util they have before performing actions that require
+   * a logged-in user
+   * @example
+   * await client.waitUntilConnected()
+   * client.sendChatMessage('Hey friends, I'm connected!', 'friends')
+   * @returns {Promise<true>}
    */
-  static async GetConnected (client) {
-    if (client.connected) {
-      return client;
+  async waitUntilConnected () {
+    if (this.connected) {
+      return true
     }
 
-    return new Promise(res => client.addEventListener("immers-client-connected", () => res(client), { once: true }));
+    return new Promise(resolve => {
+      this.addEventListener('immers-client-connected', () => resolve(true), { once: true })
+    })
   };
 
   /**

--- a/source/client.js
+++ b/source/client.js
@@ -885,10 +885,10 @@ export class ImmersClient extends window.EventTarget {
    * Links in ActivityPub objects can take a variety of forms.
    * Find and return the URL string.
    * @param  {Activities.APObject|object|string} prop
-   * @returns {string} URL string
+   * @returns {(string|undefined)} URL string, if present
    */
   static URLFromProperty (prop) {
-    return prop?.url?.href ?? prop?.url ?? prop
+    return prop?.url?.href ?? prop?.url ?? prop?.href ?? prop
   }
 
   async #setPlaceFromDestination (destinationDescription) {

--- a/source/streaming.js
+++ b/source/streaming.js
@@ -59,7 +59,7 @@ export class ImmersSocket extends window.EventTarget {
         actor: actorObj.id,
         target: place,
         to: actorObj.followers,
-        summary: htmlAnchorForPlace(place)
+        summary: `<span>Left ${htmlAnchorForPlace(place)}</span>`
       }
     })
   }


### PR DESCRIPTION
### Added

* New event `immers-client-profile-update` fires whenever logged-in user's profile
has changed
* New method `immersClient.waitUntilConnected`, utility to simplify timing checks when a logged-in user is required 
* New static method `ImmersClient.DestinationFromPlace` to transform ActivityPub Place to Destination type

### Changed

* Added `bio` and `avatarObject` to `Profile`
* Added `inbox` and `outbox` to `Profile.collections`
* Added `destination` to `FriendStatus`
* `URLFromProperty` can also find `href` prop if given a `Link` object
* `Activities.getObject` can accept URL object in addition to string
* Destination urls ending with an empty fragment will have the trailing `#` dropped to more accutately aggregate Destinations history

### Fixed

* Restore summary messages in arrive/leave activities
* Fix local immer place object not updating
* Fix error in Profile type, url for avatar 3d Model is in prop `avatarModel` not `avatarGltf`