### PR TITLE
immers link navigation utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Added
+
+* `Immersclient.navigateToImmersLink` - navigate to a given URL while passing along the user's handle so they don't have to re-enter it at the next destination
+* `ImmersClient.handleImmersLinkClick` - onClick handler to make navigating between immers easier by passing along the user's handle
+
 ## v2.10.0 (2022-10-05)
 
 ### Added

--- a/source/client.js
+++ b/source/client.js
@@ -721,6 +721,52 @@ export class ImmersClient extends window.EventTarget {
     return info
   }
 
+  /**
+   * Make navigating between immers easier by providing the user's
+   * handle to the next experience so they don't have to type it in.
+   * Use as an onClick handler to inject the "me hash" into any cross-origin
+   * anchor when navigating. Can be registered directly on the anchor
+   * or on a parent element.
+   * Will fallback to default click behavior if same-origin, not logged in,
+   * or unable to process url.
+   * @param  {MouseEvent} clickEvent
+   */
+  handleImmerLinkClick (clickEvent) {
+    const a = clickEvent.composedPath()
+      .find(element => element.tagName === 'A')
+    if (!a) {
+      return
+    }
+    if (this.profile && a.origin !== window.location.origin) {
+      try {
+        this.navigateToImmerLink(a.href)
+        clickEvent.preventDefault()
+      } catch (ignore) {
+        /* if fail, leave original url unchanged */
+      }
+    }
+  }
+
+  /**
+   * Navigate to a given url while injecting a "me hash" to provide the
+   * user's handle to the destination site so that they don't have to re-enter it.
+   * Safe to use without checking if user is logged in, will just navigate normally
+   * if not
+   * @param  {string} href
+   */
+  navigateToImmerLink (href) {
+    const url = new URL(href)
+    if (this.profile) {
+      const hashParams = new URLSearchParams(
+        // preserve original hash if present, must strip '#' to avoid doubling it
+        url.hash.replace(/^#/, '')
+      )
+      hashParams.set('me', this.profile.handle)
+      url.hash = hashParams.toString()
+    }
+    window.location = url
+  }
+
   async #publishFriendsUpdate () {
     /**
      * Friends status/location has changed


### PR DESCRIPTION
Utilities to easily include the "me hash" in <a> & programmatic navigation so that users don't have to re-enter their handles when following a friends list link