### PR TITLE
Non popup token retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Changed
+
+* `catchToken` will now return the token and associated data if it does not detect an opener window to pass the data to
+* `ImmersClient.loginWithToken` now also accepts sessionInfo parameter to be fully equivalent with regular login
+
 ## v2.16.0 (2023-03-29)
 
 ### Added

--- a/oneLiner.js
+++ b/oneLiner.js
@@ -10,7 +10,7 @@ try {
   console.warn(`Unable to process query arguments to script, ${err.message}`)
 }
 (async function () {
-  if (catchToken()) {
+  if (catchToken() === true) {
     // token was passed to opener window; this is just a popup
     return
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "standard",
     "doc": "jsdoc -c jsdoc.config.json -d doc -r source/. -R README.md && cp -R readme_files doc/",
     "build": "webpack --config webpack.prod.js",
-    "type": "tsc index.js source/**/*.js -t es2020 --declaration --skipLibCheck --allowJs --emitDeclarationOnly --moduleResolution node --outDir types",
+    "type": "tsc index.js -t es2020 --declaration --skipLibCheck --allowJs --emitDeclarationOnly --moduleResolution node --outDir types",
     "dev": "webpack serve --open --config webpack.dev.js",
     "prepare": "npm run type && npm run build"
   },

--- a/source/authUtils.js
+++ b/source/authUtils.js
@@ -42,8 +42,18 @@ export const allScopes = [
 export const roles = ['public', 'friends', 'modAdditive', 'modFull']
 
 /**
+ * @typedef {object} TokenResult
+ * @property {string} token OAuth access token
+ * @property {string} homeImmer User's home Immers Server origin
+ * @property {Array<string>} authorizedScopes Scopes granted by user (may differ from requested scopes)
+ * @property {object} sessionInfo Any other params returned from the authorization server with the token
+ */
+/**
  * Retrieve OAuth access token and authorization details from URL after
- * redirect and pass it back to the opening window if in a pop-up
+ * redirect and pass it back to the opening window if in a pop-up. Returns true
+ * if a token was found and passed from popup to opener. Returns the token response
+ * data if a token was found but the window is not a popup. Returns false if no token found.
+ * @returns {boolean | TokenResult}
  */
 export function catchToken () {
   const hashParams = new URLSearchParams(window.location.hash.substring(1))
@@ -58,16 +68,23 @@ export function catchToken () {
     const sessionInfo = Object.fromEntries(hashParams)
     window.location.hash = ''
     // If this is an oauth popup, pass the results back up and close
-    // todo check origin
-    if (window.opener) {
-      window.opener.postMessage({
-        type: 'ImmersAuth',
-        token,
-        homeImmer,
-        authorizedScopes,
-        sessionInfo
-      })
-      return true
+    try {
+      if (window.opener?.location.origin === window.location.origin) {
+        window.opener.postMessage({
+          type: 'ImmersAuth',
+          token,
+          homeImmer,
+          authorizedScopes,
+          sessionInfo
+        })
+        return true
+      }
+    } catch {}
+    return {
+      token,
+      homeImmer,
+      authorizedScopes,
+      sessionInfo
     }
   } else if (hashParams.has('error')) {
     window.opener?.postMessage({ type: 'ImmersAuth', error: hashParams.get('error') })

--- a/source/authUtils.js
+++ b/source/authUtils.js
@@ -52,7 +52,9 @@ export const roles = ['public', 'friends', 'modAdditive', 'modFull']
  * Retrieve OAuth access token and authorization details from URL after
  * redirect and pass it back to the opening window if in a pop-up. Returns true
  * if a token was found and passed from popup to opener. Returns the token response
- * data if a token was found but the window is not a popup. Returns false if no token found.
+ * data if a token was found but the window is not a popup
+ * (e.g. to pass on to [ImmersClient.loginWithToken]{@link ImmersClient#loginWithToken}).
+ * Returns false if no token found.
  * @returns {boolean | TokenResult}
  */
 export function catchToken () {

--- a/source/client.js
+++ b/source/client.js
@@ -189,7 +189,8 @@ export class ImmersClient extends window.EventTarget {
 
   /**
    * Initialize client with an existing credential,
-   * e.g. one obtained through a service account
+   * e.g. one obtained through a service account or one returned from {@link catchToken}
+   * when performing a redirect based OAuth flow
    * @param  {string} token - OAuth2 Access Token
    * @param  {string} homeImmer - Domain (host) for user's home immer
    * @param  {(string|string[])} authorizedScopes - Scopes authorized for the token

--- a/source/client.js
+++ b/source/client.js
@@ -193,12 +193,13 @@ export class ImmersClient extends window.EventTarget {
    * @param  {string} token - OAuth2 Access Token
    * @param  {string} homeImmer - Domain (host) for user's home immer
    * @param  {(string|string[])} authorizedScopes - Scopes authorized for the token
+   * @param {object} [sessionInfo] - optional session data provided alongside token
    * @returns {Promise<boolean>} true if the login was successful
    */
-  loginWithToken (token, homeImmer, authorizedScopes) {
+  loginWithToken (token, homeImmer, authorizedScopes, sessionInfo) {
     homeImmer = getURLPart(homeImmer, 'origin')
     authorizedScopes = preprocessScopes(authorizedScopes)
-    this.#store.credential = { token, homeImmer, authorizedScopes }
+    this.#store.credential = { token, homeImmer, authorizedScopes, sessionInfo }
     return this.restoreSession()
   }
 


### PR DESCRIPTION
Allow receiving OAuth token in the current window if not currently in a popup. This allows redirect-based auth flows like SAML's IdP-Initiated SSO